### PR TITLE
Fix failed projects

### DIFF
--- a/project-moonbeam.yaml
+++ b/project-moonbeam.yaml
@@ -21,7 +21,7 @@ network:
     file: ./dist/moonbeamChaintypes.js
 dataSources:
   - kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 150000
     mapping:
       file: ./dist/index.js
       handlers:

--- a/project-moonriver.yaml
+++ b/project-moonriver.yaml
@@ -21,7 +21,7 @@ network:
     file: ./dist/moonbeamChaintypes.js
 dataSources:
   - kind: substrate/Runtime
-    startBlock: 1
+    startBlock: 390000
     mapping:
       file: ./dist/index.js
       handlers:

--- a/project-polkadex.yaml
+++ b/project-polkadex.yaml
@@ -15,7 +15,7 @@ schema:
 network:
   chainId: '0x3920bcb4960a1eef5580cd5367ff3f430eef052774f78468852f7b9cb39f8a3c'
   endpoint: >-
-    wss://mainnet.polkadex.trade
+    wss://polkadex.api.onfinality.io/public-ws
   chaintypes:
     file: ./dist/polkadexChaintypes.js
 dataSources:


### PR DESCRIPTION
That PR fixes problems with SubQuery deployment from 1 block, what was fixed:

- Polkadex changed node from prune to archive
- Change Moonbeam/Moonriver start block to which we use in subquery-nova project. 
-- https://github.com/nova-wallet/subquery-nova/blob/bb9f90a1bd1d1978a15bd9f6bd4e2303c6409d4d/moonriver.yaml#L25
-- https://github.com/nova-wallet/subquery-nova/blob/bb9f90a1bd1d1978a15bd9f6bd4e2303c6409d4d/moonbeam.yaml#L25